### PR TITLE
Fix import issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # OS
 .DS_Store
 Thumbs.db
+.idea
 
 # Composer
 /composer.lock

--- a/src/Event/ApiResponseBodyEvent.php
+++ b/src/Event/ApiResponseBodyEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WordPressImportBundle\Event;
+
+use GuzzleHttp\Client;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ApiResponseBodyEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $body;
+    /**
+     * @var Client
+     */
+    private $client;
+    /**
+     * @var string
+     */
+    private $endpoint;
+
+    public function __construct(string $body, Client $client, string $endpoint)
+    {
+        $this->body = $body;
+        $this->client = $client;
+        $this->endpoint = $endpoint;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    public function setBody(string $body): void
+    {
+        $this->body = $body;
+    }
+}

--- a/src/EventListener/ApiResponseBodyListener.php
+++ b/src/EventListener/ApiResponseBodyListener.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WordPressImportBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use WordPressImportBundle\Event\ApiResponseBodyEvent;
+
+class ApiResponseBodyListener implements EventSubscriberInterface
+{
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ApiResponseBodyEvent::class => 'onApiResponseBodyEvent',
+        ];
+    }
+
+    public function onApiResponseBodyEvent(ApiResponseBodyEvent $event)
+    {
+        $json = $event->getBody();
+
+        // Remove hidden characters from json (https://stackoverflow.com/questions/17219916/json-decode-returns-json-error-syntax-but-online-formatter-says-the-json-is-ok)
+        for ($i = 0; $i <= 31; ++$i) {
+            $json = str_replace(\chr($i), '', $json);
+        }
+        $json = str_replace(\chr(127), '', $json);
+
+        if (0 === strpos(bin2hex($json), 'efbbbf')) {
+            $json = substr($json, 3);
+        }
+
+        $event->setBody($json);
+    }
+
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     _defaults:
         autoconfigure: true
-        public: false 
+        public: false
 
     wordpressimporter:
         class: WordPressImportBundle\Service\Importer
@@ -20,3 +20,6 @@ services:
         public: true
         class: WordPressImportBundle\Utils\Cron
         arguments: ['@wordpressimporter', '@logger', '@contao.framework']
+
+    WordPressImportBundle\EventListener\ApiResponseBodyListener:
+        autowire: true

--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -218,16 +218,6 @@ class Importer
     {
         $json = $client->get($endpoint, ['query' => $params])->getBody()->getContents();
 
-        // Remove hidden characters from json (https://stackoverflow.com/questions/17219916/json-decode-returns-json-error-syntax-but-online-formatter-says-the-json-is-ok)
-        for ($i = 0; $i <= 31; ++$i) {
-            $json = str_replace(\chr($i), '', $json);
-        }
-        $json = str_replace(\chr(127), '', $json);
-
-        if (0 === strpos(bin2hex($json), 'efbbbf')) {
-            $json = substr($json, 3);
-        }
-
         $event = $this->eventDispatcher->dispatch(new ApiResponseBodyEvent($json, $client, $endpoint));
 
         return json_decode($event->getBody());


### PR DESCRIPTION
This PR fix two issues we encountered when importing posts from a wordpress installation.

The first one was a curious issues with invalid json returning from the Wordpress REST API. We got style tags added to the response text before the actual json object began (I think some plugin or theme does some wordpress-magic there). So I added a simple check if the string starts with json syntax, otherwise the string invalid parts will be removed.

The second one enhances the import of files, as we got issues with the current implementation. We got paths with 'startfolder/../../resultfolder' in, where the startfolder did not exist in the local file system. The Dbfs class seems to have issues with such constellations. So I adjusted the path generation a little bit.

BTW: Thanks for this great extension!